### PR TITLE
Update rebar.config.script

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -18,7 +18,7 @@
 %%% OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 %%%=============================================================================
 
-ProperGithub = {git, "https://github.com/manopapad/proper.git", {tag, "v1.1"}}.
+ProperGithub = {git, "https://github.com/manopapad/proper.git", {tag, "v1.2"}}.
 
 case erlang:function_exported(rebar3, main, 1) of
     true  ->
@@ -27,7 +27,7 @@ case erlang:function_exported(rebar3, main, 1) of
           [
            {test,
             [
-             {deps, [{proper, "1.1.0"}]},
+             {deps, [{proper, "1.2.0"}]},
              {proper_opts, [long_result, verbose]}
             ]}
           ]},


### PR DESCRIPTION
Seems like some functions are deprecated


```
~/src/libkvm$ MIX_ENV=prod mix compile --env=prod
===> Compiling proper
make: `include/compile_flags.hrl' is up to date.
===> Compiling src/proper_gb_sets.erl failed
src/proper_gb_sets.erl:41: type gb_sets() undefined

** (Mix) Could not compile dependency :proper, "/Users/seydou.dia/.mix/rebar3 bare compile --paths "/Users/seydou.dia/src/libkvm/_build/prod/lib/*/ebin"" command failed. You can recompile this dependency with "mix deps.compile proper", update it with "mix deps.update proper" or clean it with "mix deps.clean proper"
```